### PR TITLE
Refactor for `#![no_std]` usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
+extern crate alloc;
+
 use core::mem;
+use alloc::vec::Vec;
 
 const fn pos<K>(l: &usize, _: &K, _: &Vec<K>) -> usize {
     *l

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use core::mem;
 
 const fn pos<K>(l: &usize, _: &K, _: &Vec<K>) -> usize {
     *l

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,6 @@
 use crate::Vectorable;
+use alloc::vec::Vec;
+use alloc::string::String;
 
 #[doc(hidden)]
 #[macro_export]


### PR DESCRIPTION
Can’t use this crate in a low-level project like an OS kernel without these changes.